### PR TITLE
Adjust issue with the leaderboards calculation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,6 @@ end
 
 group :development do
   gem 'pry-byebug', platform: [:ruby_20], require: false
-  gem "byebug"
   gem "sqlite3", "~> 1.3.6"
   gem 'spring'
 end
@@ -61,6 +60,7 @@ group :development, :test do
   gem 'vcr'
   gem 'webmock'
   gem 'faraday'
+  gem "byebug"
 end
 
 # Use unicorn as the app server

--- a/app/models/concerns/calculation.rb
+++ b/app/models/concerns/calculation.rb
@@ -3,9 +3,9 @@ require 'active_support/concern'
 module Calculation
   extend ActiveSupport::Concern
 
-  def minutes_of_current_week
-    start_date = Time.now.beginning_of_week.to_date
-    end_date = Time.now.end_of_week.to_date
+  def minutes_of_week(weeks_ago)
+    start_date = (Time.now.beginning_of_week - weeks_ago.week).to_date
+    end_date = (Time.now.end_of_week - weeks_ago.week).to_date
     entries.where(date: start_date..end_date).sum(:minutes)
   end
 end

--- a/app/models/concerns/leaderboard_calculation.rb
+++ b/app/models/concerns/leaderboard_calculation.rb
@@ -5,16 +5,20 @@ module LeaderboardCalculation
 
   included do
     def self.calculate
-      start_date = Time.now.beginning_of_week.to_date
-      end_date = Time.now.end_of_week.to_date
-      model_klass = self.name.gsub("Leaderboard", "").constantize
+      [1, 0].each do |weeks_ago|
+        start_date = Time.now.beginning_of_week.to_date - weeks_ago.weeks
+        end_date = Time.now.end_of_week.to_date - weeks_ago.weeks
+        model_klass = self.name.gsub("Leaderboard", "").constantize
 
-      model_klass.find_each do |record|
-        leaderboard = self.find_or_create_by(
-          "#{model_klass.name.downcase}_id" => record.id,
-          start_date: start_date,
-          end_date: end_date)
-        leaderboard.update_column(:total_minutes, record.minutes_of_current_week)
+        puts "Calculating time from #{start_date} to #{end_date} of #{model_klass}"
+
+        model_klass.find_each do |record|
+          leaderboard = self.find_or_create_by(
+            "#{model_klass.name.downcase}_id" => record.id,
+            start_date: start_date,
+            end_date: end_date)
+          leaderboard.update_column(:total_minutes, record.minutes_of_week(weeks_ago))
+        end
       end
     end
   end

--- a/app/models/concerns/leaderboard_calculation.rb
+++ b/app/models/concerns/leaderboard_calculation.rb
@@ -10,8 +10,6 @@ module LeaderboardCalculation
         end_date = Time.now.end_of_week.to_date - weeks_ago.weeks
         model_klass = self.name.gsub("Leaderboard", "").constantize
 
-        puts "Calculating time from #{start_date} to #{end_date} of #{model_klass}"
-
         model_klass.find_each do |record|
           leaderboard = self.find_or_create_by(
             "#{model_klass.name.downcase}_id" => record.id,

--- a/spec/models/project_leaderboard_spec.rb
+++ b/spec/models/project_leaderboard_spec.rb
@@ -35,7 +35,7 @@ describe ProjectLeaderboard do
       it "is not generating the leaderboard" do
         expect do
           ProjectLeaderboard.calculate
-        end.to change(ProjectLeaderboard.where(total_minutes: 0), :count).by(1)
+        end.to change(ProjectLeaderboard.where(total_minutes: 0), :count).by(2)
       end
     end
 
@@ -46,7 +46,7 @@ describe ProjectLeaderboard do
         expect { ProjectLeaderboard.calculate }.to change(
           ProjectLeaderboard.where(total_minutes: 0),
           :count
-        ).by(0)
+        ).by(1)
 
         expect(ProjectLeaderboard.where(
           total_minutes: entry.minutes).count).to eq(1)

--- a/spec/models/user_leaderboard_spec.rb
+++ b/spec/models/user_leaderboard_spec.rb
@@ -38,7 +38,7 @@ describe UserLeaderboard do
       it "is not generating the leaderboard" do
         expect do
           UserLeaderboard.calculate
-        end.to change(UserLeaderboard.where(total_minutes: 0), :count).by(1)
+        end.to change(UserLeaderboard.where(total_minutes: 0), :count).by(2)
       end
     end
 
@@ -49,7 +49,7 @@ describe UserLeaderboard do
         expect { UserLeaderboard.calculate }.to change(
           UserLeaderboard.where(total_minutes: 0),
           :count
-        ).by(0)
+        ).by(1)
 
         expect(UserLeaderboard.where(
           total_minutes: entry.minutes).count).to eq(1)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -90,19 +90,19 @@ describe User do
     end
   end
 
-  describe '#minutes_of_current_week' do
+  describe '#minutes_of_week' do
     let(:user)   { create(:user) }
     let!(:entry) { create(:entry, minutes: 1337, user_id: user.id) }
 
     it 'sums up the correct amount of minutes for user in current week' do
-      expect(user.minutes_of_current_week).to eq(1337)
+      expect(user.minutes_of_week(0)).to eq(entry.minutes)
     end
 
     context 'with entry from last week' do
-      let!(:other_entry) { create(:entry, minutes: 10, user_id: user.id, date: 1.week.ago) }
+      let!(:other_entry) { create(:entry, minutes: 10, user_id: user.id, date: 1.week.ago.beginning_of_week) }
 
       it 'does not sum up minutes from last week' do
-        expect(user.minutes_of_current_week).to eq(1337)
+        expect(user.minutes_of_week(1)).to eq(other_entry.minutes)
       end
     end
   end


### PR DESCRIPTION
Hey guys,

In PR https://github.com/fastruby/pecas/pull/54 we changed the import service to get the entries from the last 2 weeks to include the scenarios when we add time for the week before.

But we forgot to also update the leaderboard calculation to reflect that change. So this is what this PR is about.

Please, take a look thanks!