### PR TITLE
[README UPDATE] Replace `rails server` with `docker-compose up`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ the emails will be sent on holidays.
 
 ## Start
 
-    rails server
+    docker-compose up
 
 ## Import
 


### PR DESCRIPTION
If setup was done using Docker, the command to start the app should be `docker-compose up`