### PR TITLE
Migrate factory bot rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec-rails'
   gem 'email_spec'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'simplecov', require: false
   gem 'simplecov-console', require: false
   gem 'coveralls', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,11 +76,11 @@ GEM
       mail (~> 2.7)
     erubis (2.7.0)
     execjs (2.8.1)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
+    factory_bot (6.2.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.2.0)
+      factory_bot (~> 6.2.0)
+      railties (>= 5.0.0)
     faraday (1.4.2)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -277,7 +277,7 @@ DEPENDENCIES
   coveralls
   dotenv-rails
   email_spec
-  factory_girl_rails
+  factory_bot_rails
   faraday
   holidays
   jbuilder (~> 2.0)

--- a/db/seeds/development.rb
+++ b/db/seeds/development.rb
@@ -1,9 +1,9 @@
-require 'factory_girl'
-FactoryGirl.find_definitions
+require 'factory_bot'
+FactoryBot.find_definitions
 
-user_1 = FactoryGirl.create :user, name: "Hans"
-user_2 = FactoryGirl.create :user, name: "Franz"
-user_3 = FactoryGirl.create :user, name: "Otto"
+user_1 = FactoryBot.create :user, name: "Hans"
+user_2 = FactoryBot.create :user, name: "Franz"
+user_3 = FactoryBot.create :user, name: "Otto"
 
 project_1 = Project.create name: 'OmbuLabs'
 project_2 = Project.create name: 'OmbuShop'

--- a/spec/controllers/leaderboard_controller_spec.rb
+++ b/spec/controllers/leaderboard_controller_spec.rb
@@ -16,16 +16,16 @@ describe LeaderboardController, type: :controller do
     end
 
     context "leaderboard exists" do
-      let(:project) { FactoryGirl.create :project }
+      let(:project) { FactoryBot.create :project }
       let!(:leaderboard_1) {
-        FactoryGirl.create :project_leaderboard,
+        FactoryBot.create :project_leaderboard,
                            total_minutes: 1920,
                            start_date: Time.new(2015, 07, 6, 0, 0, 0).to_date,
                            end_date: Time.new(2015, 07, 12, 0, 0, 0).to_date,
                            project: project
       }
       let!(:leaderboard_2) {
-        FactoryGirl.create :project_leaderboard,
+        FactoryBot.create :project_leaderboard,
                            total_minutes: 1740,
                            start_date: Time.new(2015, 07, 13, 0, 0, 0).to_date,
                            end_date: Time.new(2015, 07, 19, 0, 0, 0).to_date,
@@ -45,7 +45,7 @@ describe LeaderboardController, type: :controller do
 
       context "project without logged minutes" do
         let!(:leaderboard_2) {
-          FactoryGirl.create :project_leaderboard,
+          FactoryBot.create :project_leaderboard,
                              total_minutes: 0,
                              start_date: Time.new(2015, 07, 13, 0, 0, 0).to_date,
                              end_date: Time.new(2015, 07, 19, 0, 0, 0).to_date,
@@ -110,16 +110,16 @@ describe LeaderboardController, type: :controller do
     end
 
     context "leaderboard exists" do
-      let(:user) { FactoryGirl.create :user }
+      let(:user) { FactoryBot.create :user }
       let!(:leaderboard_1) {
-        FactoryGirl.create :user_leaderboard,
+        FactoryBot.create :user_leaderboard,
                            total_minutes: 1920,
                            start_date: Time.new(2015, 07, 6, 0, 0, 0).to_date,
                            end_date: Time.new(2015, 07, 12, 0, 0, 0).to_date,
                            user: user
       }
       let!(:leaderboard_2) {
-        FactoryGirl.create :user_leaderboard,
+        FactoryBot.create :user_leaderboard,
                            total_minutes: 1740,
                            start_date: Time.new(2015, 07, 13, 0, 0, 0).to_date,
                            end_date: Time.new(2015, 07, 19, 0, 0, 0).to_date,
@@ -139,7 +139,7 @@ describe LeaderboardController, type: :controller do
 
       context "user without logged minutes" do
         let!(:leaderboard_2) {
-          FactoryGirl.create :user_leaderboard,
+          FactoryBot.create :user_leaderboard,
                              total_minutes: 0,
                              start_date: Time.new(2015, 07, 13, 0, 0, 0).to_date,
                              end_date: Time.new(2015, 07, 19, 0, 0, 0).to_date,

--- a/spec/factories/entry.rb
+++ b/spec/factories/entry.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :entry do
     description 'hello world'
     minutes 10

--- a/spec/factories/entry.rb
+++ b/spec/factories/entry.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :entry do
-    description 'hello world'
-    minutes 10
-    date Date.today
+    description { 'hello world' }
+    minutes { 10 }
+    date { Date.today }
   end
 end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :project do
     sequence(:name) {|n| "project_#{n}"}
     enabled { true }

--- a/spec/factories/project_leaderboard.rb
+++ b/spec/factories/project_leaderboard.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :project_leaderboard do
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     sequence(:name) {|n| "name_#{n}"}
     sequence(:email) {|n| "name_#{n}@example.com"}

--- a/spec/factories/user_leaderboard.rb
+++ b/spec/factories/user_leaderboard.rb
@@ -1,4 +1,4 @@
-FactoryGirl.define do
+FactoryBot.define do
   factory :user_leaderboard do
   end
 end

--- a/spec/mailers/reminder_spec.rb
+++ b/spec/mailers/reminder_spec.rb
@@ -5,7 +5,7 @@ describe 'Reminder Mailer' do
   include EmailSpec::Matchers
 
   let(:receiver) { 'test@example.com' }
-  let(:user)     { FactoryGirl.create(:user, name: 'Foo', email: receiver) }
+  let(:user)     { FactoryBot.create(:user, name: 'Foo', email: receiver) }
   let(:email)    { Reminder.send_to(user) }
 
   it "should be set to be delivered to the email passed in" do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -48,7 +48,7 @@ end
 RSpec.configure do |config|
   config.include EmailSpec::Helpers
   config.include EmailSpec::Matchers
-  config.include FactoryGirl::Syntax::Methods
+  config.include FactoryBot::Syntax::Methods
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"


### PR DESCRIPTION
**Introduction:**

This PR upgrades `FactoryGirl` to `FactoryBot`, which fixes deprecation warning logged by `factory_girl_rails` gem.

Merging this PR will close issue #84. 


**Description:**

This PR contains upgradation from `factory_girl_rails:4.9.0` to `factory_bot_rails:6.2.0` gem. And mandatory changes required for `FactoryBot`.


**Before Fix:**

While running test suite with command `bundle exec rspec spec`, deperecation warnings were getting logged as mentioned below.
```
DEPRECATION WARNING: The factory_girl gem is deprecated. Please upgrade to factory_bot. See https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md for further instructions. (called from require at /Users/etagwerker/.rvm/rubies/ruby-2.5.8/lib/ruby/site_ruby/2.5.0/bundler/runtime.rb:81)
```

**After Fix:**

While running test suite, deprecation warnings are no longer been logged.


**Future Conventions:**

Implement test suites using `FactoryBot` instead of `FactoryGirl`.


I will abide by the [code of conduct](code_of_conduct.md).