### PR TITLE
Add a task to delete entries older than a given number of months

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,13 @@ Generate demo data with:
 
     rake demo_data:setup
 
+## Deleting old data
+
+You can run this task specifying the number of months ago for the query:
+
+    # delete entries with date older than 6 months ago
+    MONTHS=6 rake delete_past_entries
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at [https://github.com/fastruby/pecas](https://github.com/fastruby/pecas). This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -3,4 +3,8 @@ class Entry < ActiveRecord::Base
   belongs_to :project
 
   scope :today, lambda { where(date: Date.today) }
+
+  def self.delete_older_than(date)
+    where('date < ?', date).delete_all
+  end
 end

--- a/lib/tasks/delete_past_entries.rake
+++ b/lib/tasks/delete_past_entries.rake
@@ -1,0 +1,11 @@
+desc "Deletes entries older than the specified months ago"
+task delete_past_entries: :environment do
+  if ENV["MONTHS"].blank?
+    puts "Please specify the number of months ago to delete with the MONTHS env variable. Example: `MONTHS=5 bundle exec rake delete_past_entries"
+  else
+    date = ENV["MONTHS"].to_i.months.ago
+    puts "deleting entries older than #{date}"
+    Entry.delete_older_than(date)
+    puts "finished deleting past entries"
+  end
+end

--- a/spec/models/entry_spec.rb
+++ b/spec/models/entry_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe Entry do
+  describe "#delete_past_entries" do
+    it "deletes entries older than the given date" do
+      Entry.delete_all
+
+      old_entry = create :entry, date: 11.months.ago
+      new_entry = create :entry, date: 3.months.ago
+
+      expect do
+        Entry.delete_older_than(5.months.ago)
+      end.to change(Entry, :count).from(2).to(1)
+
+      expect(Entry.exists?(new_entry.id)).to be_truthy
+      expect(Entry.exists?(old_entry.id)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
**Description:**

This PR adds a rake task that can be used to automate the deletion of older entries.

I paired with @FionaDL on this.

Closes #104 

I will abide by the [code of conduct](code_of_conduct.md).
