### PR TITLE
Add rack mini profiler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,6 +46,7 @@ gem 'jbuilder', '~> 2.0'
 gem 'holidays'
 
 gem 'json'
+gem 'rack-mini-profiler'
 
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,8 @@ GEM
     public_suffix (4.0.6)
     racc (1.5.2)
     rack (2.2.3.1)
+    rack-mini-profiler (3.0.0)
+      rack (>= 1.2.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.7)
@@ -299,6 +301,7 @@ DEPENDENCIES
   noko
   pg
   pry-byebug
+  rack-mini-profiler
   rails (~> 5.1.0)
   rails-controller-testing
   rails_12factor

--- a/config/initializers/rack_mini_profiler.rb
+++ b/config/initializers/rack_mini_profiler.rb
@@ -1,0 +1,2 @@
+Rack::MiniProfiler.config.start_hidden = true
+Rack::MiniProfiler.config.toggle_shortcut = "Alt+Ctrl+P"


### PR DESCRIPTION
**Description:**

To be able to analyze queries performance.

The widget is invisible by default, to display it press Alt+Ctrl+P (windows/linux) or Option+Ctrl+P (Mac)

I will abide by the [code of conduct](code_of_conduct.md).
