### PR TITLE
[PEC-5] Fix Pecas notification formatting

### DIFF
--- a/app/services/slack_service/group_member_messaging.rb
+++ b/app/services/slack_service/group_member_messaging.rb
@@ -83,13 +83,7 @@ class SlackService::GroupMemberMessaging
 
     def format_desc(entries)
       entries.map do |entry|
-        formatted_desc = entry.description.split(" ").map do |word|
-          if word.include?("#")
-            word = "`#{word}`"
-          else
-            word
-          end
-        end.join(" ")
+        formatted_desc = entry.description.gsub(/(#\w+\W)/) { |label| "`#{label}` " }
         "* #{formatted_desc} (#{entry.length})"
       end.join("\n")
     end

--- a/app/services/slack_service/group_member_messaging.rb
+++ b/app/services/slack_service/group_member_messaging.rb
@@ -83,7 +83,7 @@ class SlackService::GroupMemberMessaging
 
     def format_desc(entries)
       entries.map do |entry|
-        formatted_desc = entry.description.gsub(/(#\w+\W)/) { |label| "`#{label}` " }
+        formatted_desc = entry.description.gsub(/(#[a-zA-Z|*|-]+)(?:)/) { |label| "`#{label}` " }
         "* #{formatted_desc} (#{entry.length})"
       end.join("\n")
     end

--- a/app/services/slack_service/group_member_messaging.rb
+++ b/app/services/slack_service/group_member_messaging.rb
@@ -27,6 +27,17 @@ class SlackService::GroupMemberMessaging
     :ok
   end
 
+  def self.format_desc(entries)
+    entries.map do |entry|
+      format_entry(entry)
+    end.join("\n")
+  end
+
+  def self.format_entry(entry)
+    formatted_desc = entry.description.gsub(DESC_REGEX) { |label| "`#{label}` " }
+    "* #{formatted_desc} (#{entry.length})"
+  end
+
     private
 
     def connect_client
@@ -72,7 +83,7 @@ class SlackService::GroupMemberMessaging
           },
           {
             "type": "section",
-            "text": { "type": "mrkdwn", "text": format_desc(entries)}
+            "text": { "type": "mrkdwn", "text": SlackService::GroupMemberMessaging.format_desc(entries)}
           },
           {
             "type": "section",
@@ -80,13 +91,6 @@ class SlackService::GroupMemberMessaging
           },
         ]
       }
-    end
-
-    def format_desc(entries)
-      entries.map do |entry|
-        formatted_desc = entry.description.gsub(DESC_REGEX) { |label| "`#{label}` " }
-        "* #{formatted_desc} (#{entry.length})"
-      end.join("\n")
     end
 
     def time_entry_format_warning_prefix(member)

--- a/app/services/slack_service/group_member_messaging.rb
+++ b/app/services/slack_service/group_member_messaging.rb
@@ -42,7 +42,7 @@ class SlackService::GroupMemberMessaging
         if now.in_time_zone(data.tz).hour == actionable_hour
           users[data.email] = data
         end
-        
+
         users
       end
     end
@@ -71,7 +71,7 @@ class SlackService::GroupMemberMessaging
           },
           {
             "type": "section",
-            "text": { "type": "mrkdwn", "text": entries.map{|entry| "* #{entry.description} (#{entry.length})" }.join("\n") }
+            "text": { "type": "mrkdwn", "text": format_desc(entries)}
           },
           {
             "type": "section",
@@ -79,6 +79,19 @@ class SlackService::GroupMemberMessaging
           },
         ]
       }
+    end
+
+    def format_desc(entries)
+      entries.map do |entry|
+        formatted_desc = entry.description.split(" ").map do |word|
+          if word.include?("#")
+            word = "`#{word}`"
+          else
+            word
+          end
+        end.join(" ")
+        "* #{formatted_desc} (#{entry.length})"
+      end.join("\n")
     end
 
     def time_entry_format_warning_prefix(member)

--- a/app/services/slack_service/group_member_messaging.rb
+++ b/app/services/slack_service/group_member_messaging.rb
@@ -1,5 +1,6 @@
 class SlackService::GroupMemberMessaging
   attr_reader :members
+  DESC_REGEX = /(#[a-zA-Z|*|-]+)(?:)/
 
   ##
   # @param [String] group_handle The id of a group from a mesdsaging service: ex @ombuteam on Slack
@@ -83,7 +84,7 @@ class SlackService::GroupMemberMessaging
 
     def format_desc(entries)
       entries.map do |entry|
-        formatted_desc = entry.description.gsub(/(#[a-zA-Z|*|-]+)(?:)/) { |label| "`#{label}` " }
+        formatted_desc = entry.description.gsub(DESC_REGEX) { |label| "`#{label}` " }
         "* #{formatted_desc} (#{entry.length})"
       end.join("\n")
     end

--- a/spec/services/slack_service/group_member_messaging_spec.rb
+++ b/spec/services/slack_service/group_member_messaging_spec.rb
@@ -119,7 +119,7 @@ describe SlackService::GroupMemberMessaging do
   describe ".format_desc" do
 
     it "formats the entry description" do
-      let(:entry_1)   { build(:entry, description: "this is an entry", minutes: 120) }
+      entry_1 = build(:entry, description: "this is an entry", minutes: 120)
 
       formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
 
@@ -127,7 +127,7 @@ describe SlackService::GroupMemberMessaging do
     end
 
     it "formats an entry description that includes a label" do
-      let(:entry_2)   { build(:entry, description: "doing something #unbillable*", minutes: 90) }
+      entry_2 = build(:entry, description: "doing something #unbillable*", minutes: 90)
 
       formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
 
@@ -135,7 +135,7 @@ describe SlackService::GroupMemberMessaging do
     end
 
     it "formats an entry with multiple labels" do
-      let(:entry_3)   { build(:entry, description: "working on #pecas  #unbillable*  #calls", minutes: 20) }
+      entry_3 = build(:entry, description: "working on #pecas  #unbillable*  #calls", minutes: 20)
 
       formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
 
@@ -144,7 +144,7 @@ describe SlackService::GroupMemberMessaging do
 
     it "formats an entry with label that incudes a dash" do
       let(:entry_4)   { build(:entry, description: "testing this entry with a dash #call-pecas  #unbillable*  #calls", minutes: 20) }
-      
+
       formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
 
       expect(formatted_entry).to eql("* testing this entry with a dash `#call-pecas`   `#unbillable*`   `#calls`  (20 minutes)")

--- a/spec/services/slack_service/group_member_messaging_spec.rb
+++ b/spec/services/slack_service/group_member_messaging_spec.rb
@@ -129,7 +129,7 @@ describe SlackService::GroupMemberMessaging do
     it "formats an entry description that includes a label" do
       entry_2 = build(:entry, description: "doing something #unbillable*", minutes: 90)
 
-      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_2)
 
       expect(formatted_entry).to eql("* doing something `#unbillable*`  (1 hour, 30 minutes)")
     end
@@ -137,15 +137,15 @@ describe SlackService::GroupMemberMessaging do
     it "formats an entry with multiple labels" do
       entry_3 = build(:entry, description: "working on #pecas  #unbillable*  #calls", minutes: 20)
 
-      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_3)
 
       expect(formatted_entry).to eql("* working on `#pecas`   `#unbillable*`   `#calls`  (20 minutes)")
     end
 
     it "formats an entry with label that incudes a dash" do
-      let(:entry_4)   { build(:entry, description: "testing this entry with a dash #call-pecas  #unbillable*  #calls", minutes: 20) }
+      entry_4 = build(:entry, description: "testing this entry with a dash #call-pecas  #unbillable*  #calls", minutes: 20)
 
-      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_4)
 
       expect(formatted_entry).to eql("* testing this entry with a dash `#call-pecas`   `#unbillable*`   `#calls`  (20 minutes)")
     end

--- a/spec/services/slack_service/group_member_messaging_spec.rb
+++ b/spec/services/slack_service/group_member_messaging_spec.rb
@@ -116,37 +116,38 @@ describe SlackService::GroupMemberMessaging do
     end
   end
 
-  describe "_format_desc" do
-    let(:entry_1)   { create(:entry, description: "this is an entry", minutes: 120) }
-    let(:entry_2)   { create(:entry, description: "doing something #unbillable*", minutes: 90) }
-    let(:entry_3)   { create(:entry, description: "working on #pecas  #unbillable*  #calls", minutes: 20) }
-    let(:entry_4)   { create(:entry, description: "testing this entry with a dash #call-pecas  #unbillable*  #calls", minutes: 20) }
-
-    before do
-      allow(Slack::Web::Client).to receive(:new).and_return(client)
-      allow(SlackService).to receive(:find_usergroup_id).with("avengers", client).and_return([:ok, "GROUPID"])
-      allow(SlackService).to receive(:find_usergroup_user_ids).with("GROUPID", client).and_return([:ok, ["USERID1", "USERID2"]])
-      allow(SlackService).to receive(:find_slack_user).with("USERID1", client).and_return([:ok, user_1])
-      allow(SlackService).to receive(:find_slack_user).with("USERID2", client).and_return([:ok, user_2])
-      @service = SlackService::GroupMemberMessaging.new("avengers", six_oclock_hour, now)
-      @message = @service.send :time_entry_format_warning_message, user_1, [entry_1, entry_2, entry_3, entry_4]
-      @formatted_list = @message[:blocks][1][:text][:text].split("\n")
-    end
+  describe ".format_desc" do
 
     it "formats the entry description" do
-      expect(@formatted_list[0]).to eql("* this is an entry (2 hours)")
+      let(:entry_1)   { build(:entry, description: "this is an entry", minutes: 120) }
+
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+
+      expect(formatted_entry).to eql("* this is an entry (2 hours)")
     end
 
     it "formats an entry description that includes a label" do
-      expect(@formatted_list[1]).to eql("* doing something `#unbillable*`  (1 hour, 30 minutes)")
+      let(:entry_2)   { build(:entry, description: "doing something #unbillable*", minutes: 90) }
+
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+
+      expect(formatted_entry).to eql("* doing something `#unbillable*`  (1 hour, 30 minutes)")
     end
 
     it "formats an entry with multiple labels" do
-      expect(@formatted_list[2]).to eql("* working on `#pecas`   `#unbillable*`   `#calls`  (20 minutes)")
+      let(:entry_3)   { build(:entry, description: "working on #pecas  #unbillable*  #calls", minutes: 20) }
+
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+
+      expect(formatted_entry).to eql("* working on `#pecas`   `#unbillable*`   `#calls`  (20 minutes)")
     end
 
     it "formats an entry with label that incudes a dash" do
-      expect(@formatted_list[3]).to eql("* testing this entry with a dash `#call-pecas`   `#unbillable*`   `#calls`  (20 minutes)")
+      let(:entry_4)   { build(:entry, description: "testing this entry with a dash #call-pecas  #unbillable*  #calls", minutes: 20) }
+      
+      formatted_entry = SlackService::GroupMemberMessaging.format_entry(entry_1)
+
+      expect(formatted_entry).to eql("* testing this entry with a dash `#call-pecas`   `#unbillable*`   `#calls`  (20 minutes)")
     end
   end
 


### PR DESCRIPTION
**Description:**

https://ombulabs.atlassian.net/browse/PEC-5

Please include a summary of the change and which issue is fixed or which feature is introduced. If changes to the behavior are made, clearly describe what changes.
If changes to the UI are made, please include screenshots of the before and after.

Update time_entry_format_warning_message to account for label included in entries that will interfere with the markdown format. 

The problem:

<img width="563" alt="Screen Shot 2022-07-08 at 8 56 58 AM" src="https://user-images.githubusercontent.com/30131907/177996409-57ba78e8-6eb0-4ffc-8c22-022c668572c8.png">

The solution: 

<img width="581" alt="image" src="https://user-images.githubusercontent.com/30131907/177996458-5c9d86f5-f450-4cd5-955a-3522accebc29.png">



I will abide by the [code of conduct](code_of_conduct.md).
