### PR TITLE
Fix database.yml aliases/overrides order

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -10,13 +10,13 @@ default: &default
   timeout: 5000
 
 development:
-  database: <%= ENV['DATABASE_NAME'] %>_development
   <<: *default
+  database: <%= ENV['DATABASE_NAME'] %>_development
 
 test:
-  database: <%= ENV['DATABASE_NAME'] %>_test
   <<: *default
+  database: <%= ENV['DATABASE_NAME'] %>_test
 
 production:
-  database: <%= ENV['DATABASE_NAME'] %>_production
   <<: *default
+  database: <%= ENV['DATABASE_NAME'] %>_production


### PR DESCRIPTION
**Description:**

I spent a couple of hours trying to understand why my `db:setup` doesn't work as expected. At first `config/database.yml` looked ok, but then I found that aliases and overrides are swapped. This PR fixes that.

Steps to reproduce the bug before this fix:
1. Clone repo.
2. Put corresponding database environment variables to `.env`.
3. Run `gem install bundler:2.2.29` and `bundle install`. 
3. Run `bin/rake db:create db:migrate db:test:prepare` (the last command from `bin/setup` script).
4. The command will try to create `pecas` database twice instead of `pecas_development` and `pecas_test`.

After this fix this steps will lead to creation and setup of databases `pecas_development` and `pecas_test`.

I will abide by the [code of conduct](code_of_conduct.md).
