### PR TITLE
[PEC-1] Remove Jira flag from entries not requiring one

### DIFF
--- a/app/domain/time_entry/description_rules.rb
+++ b/app/domain/time_entry/description_rules.rb
@@ -1,6 +1,7 @@
 class TimeEntry::DescriptionRules
   JIRA_REGEX = /(?:\s|^)([A-Z]+-[0-9]+)(?=\s|$)/
   MIN_WORD_COUNT = 4
+  KEYWORDS = ["#english", "english", "english class", "1:1", "one on one", "1-1", "end of week", "weekly call", "weekly meeting", "emails/slack", "catch up", "catching up", "standup", "stand up", "check-in", "check in", "learning", "learn", "donut"]
 
   def initialize(entry, ruleset = :internal_employee)
     @description = entry.description
@@ -26,6 +27,10 @@ class TimeEntry::DescriptionRules
       @description.downcase.include?("http")
     end
 
+    def has_keywords?
+      !!(@description.downcase =~ Regexp.union(KEYWORDS))
+    end
+
     # Removes square brackets and commas from the string before match as the
     #   "official" Jira regex won't match unless the jira id is preceeded by
     #   a space
@@ -34,6 +39,10 @@ class TimeEntry::DescriptionRules
     end
 
     def internal_employee
-      has_word_count? && (has_calls_tag? || has_url? || has_jira_ticket?)
+      if has_keywords?
+        has_word_count?
+      else
+        has_word_count? && (has_calls_tag? || has_url? || has_jira_ticket?)
+      end
     end
 end

--- a/app/domain/time_entry/description_rules.rb
+++ b/app/domain/time_entry/description_rules.rb
@@ -1,7 +1,7 @@
 class TimeEntry::DescriptionRules
   JIRA_REGEX = /(?:\s|^)([A-Z]+-[0-9]+)(?=\s|$)/
   MIN_WORD_COUNT = 4
-  KEYWORDS = ["#english", "english", "english class", "1:1", "one on one", "1-1", "end of week", "weekly call", "weekly meeting", "emails/slack", "catch up", "catching up", "standup", "stand up", "check-in", "check in", "learning", "learn", "donut"]
+  KEYWORDS = ["#english", "english", "english class", "1:1", "one on one", "1-1", "end of week", "weekly call", "weekly meeting", "emails/slack", "email", "slack" "catch up", "catching up", "standup", "stand up", "check-in", "check in", "learning", "learn", "donut"]
 
   def initialize(entry, ruleset = :internal_employee)
     @description = entry.description

--- a/spec/domain/time_entry/description_rules_spec.rb
+++ b/spec/domain/time_entry/description_rules_spec.rb
@@ -45,6 +45,20 @@ describe TimeEntry::DescriptionRules do
         expect(validator.valid?).to eql(true)
       end
 
+      it "will pass if it has a keyword" do
+        entry = Entry.new(description: "This is an English class entry")
+        validator = TimeEntry::DescriptionRules.new(entry)
+        expect(validator.valid?).to eql(true)
+
+        entry = Entry.new(description: "1:1 with Amanda entry")
+        validator = TimeEntry::DescriptionRules.new(entry)
+        expect(validator.valid?).to eql(true)
+
+        entry = Entry.new(description: "Email/Slack catch up entry")
+        validator = TimeEntry::DescriptionRules.new(entry)
+        expect(validator.valid?).to eql(true)
+      end
+
       it "will fail if too short" do
         entry = Entry.new(description: "[OSS-136]: added")
         validator = TimeEntry::DescriptionRules.new(entry)


### PR DESCRIPTION
https://ombulabs.atlassian.net/browse/PEC-1

Remove the Jira ticket flag from entries that can be easily identified as not needing one by adding .has_keywords? to DescriptionRules to validate entries containing any characters listed in KEYWORDS

I will abide by the [code of conduct](code_of_conduct.md).
