### PR TITLE
PEC-12 fix word min count

### DIFF
--- a/app/domain/time_entry/description_rules.rb
+++ b/app/domain/time_entry/description_rules.rb
@@ -1,6 +1,5 @@
 class TimeEntry::DescriptionRules
   JIRA_REGEX = /(?:\s|^)([A-Z]+-[0-9]+)(?=\s|$)/
-  MIN_WORD_COUNT = 4
 
   def initialize(entry, ruleset = :internal_employee)
     @description = entry.description
@@ -15,7 +14,7 @@ class TimeEntry::DescriptionRules
     private
 
     def has_word_count?
-      @description.split.size > MIN_WORD_COUNT - 1
+      @description.gsub(/[\[\]\,\.]/, ' ').scan(JIRA_REGEX).size > 1 && @description.split.size > 0
     end
 
     def has_calls_tag?

--- a/spec/domain/time_entry/description_rules_spec.rb
+++ b/spec/domain/time_entry/description_rules_spec.rb
@@ -46,15 +46,11 @@ describe TimeEntry::DescriptionRules do
       end
 
       it "will fail if too short" do
-        entry = Entry.new(description: "[OSS-136]: added")
+        entry = Entry.new(description: "[OSS-136]")
         validator = TimeEntry::DescriptionRules.new(entry)
         expect(validator.valid?).to eql(false)
 
-        entry = Entry.new(description: "http://www.example.com added")
-        validator = TimeEntry::DescriptionRules.new(entry)
-        expect(validator.valid?).to eql(false)
-
-        entry = Entry.new(description: "#calls added")
+        entry = Entry.new(description: "")
         validator = TimeEntry::DescriptionRules.new(entry)
         expect(validator.valid?).to eql(false)
       end


### PR DESCRIPTION
**Description:**
https://ombulabs.atlassian.net/browse/PEC-12

Individuals were receiving Pecas notifications for entries that did not require a flag. The goal is to remove this flag and only make sure that entries are flagged if they are empty or only contain a Jira ID.

- Updated has_word_count in DescriptionRules class to validate only entries that are not empty and do not contain only a Jira ID without a description. 
- Updated tests to implement has_word_count

I will abide by the [code of conduct](code_of_conduct.md).
