### PR TITLE
[PEC-12] fix word min count

### DIFF
--- a/app/domain/time_entry/description_rules.rb
+++ b/app/domain/time_entry/description_rules.rb
@@ -16,7 +16,11 @@ class TimeEntry::DescriptionRules
     private
 
     def has_word_count?
-      @description.split.size > MIN_WORD_COUNT - 1
+      if has_jira_ticket?
+        @description.split.size > 1
+      else
+        @description.split.size > 0
+      end
     end
 
     def has_calls_tag?

--- a/spec/domain/time_entry/description_rules_spec.rb
+++ b/spec/domain/time_entry/description_rules_spec.rb
@@ -45,30 +45,12 @@ describe TimeEntry::DescriptionRules do
         expect(validator.valid?).to eql(true)
       end
 
-      it "will pass if it has a keyword" do
-        entry = Entry.new(description: "This is an English class entry")
-        validator = TimeEntry::DescriptionRules.new(entry)
-        expect(validator.valid?).to eql(true)
-
-        entry = Entry.new(description: "1:1 with Amanda entry")
-        validator = TimeEntry::DescriptionRules.new(entry)
-        expect(validator.valid?).to eql(true)
-
-        entry = Entry.new(description: "Email/Slack catch up entry")
-        validator = TimeEntry::DescriptionRules.new(entry)
-        expect(validator.valid?).to eql(true)
-      end
-
       it "will fail if too short" do
-        entry = Entry.new(description: "[OSS-136]: added")
+        entry = Entry.new(description: "[OSS-136]")
         validator = TimeEntry::DescriptionRules.new(entry)
         expect(validator.valid?).to eql(false)
 
-        entry = Entry.new(description: "http://www.example.com added")
-        validator = TimeEntry::DescriptionRules.new(entry)
-        expect(validator.valid?).to eql(false)
-
-        entry = Entry.new(description: "#calls added")
+        entry = Entry.new(description: "")
         validator = TimeEntry::DescriptionRules.new(entry)
         expect(validator.valid?).to eql(false)
       end


### PR DESCRIPTION
https://ombulabs.atlassian.net/browse/PEC-12

**Description:**

Current Behaviour
Pecas is sending notifications for entries that are less than four words long. 

Expected Behaviour
Pecas should only send a notification if the description is empty or if only a Jira ticket is present in the entry


I will abide by the [code of conduct](code_of_conduct.md).
