### PR TITLE
Add VCR filters for service tokens

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,8 @@ if ENV['COVERAGE'] == "true"
   SimpleCov.start 'rails'
 end
 
+require 'vcr'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,6 +36,14 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  VCR.configure do |config|
+    config.cassette_library_dir = "fixtures/vcr_cassettes"
+    config.hook_into :webmock
+
+    config.filter_sensitive_data('$SLACK_OAUTH_TOKEN') { ENV['SLACK_OAUTH_TOKEN'] }
+    config.filter_sensitive_data('$NOKO_TOKEN') { ENV['NOKO_TOKEN'] }
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
@@ -85,4 +93,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
 end


### PR DESCRIPTION
Adds VCR configuration to filter `SLACK_OAUTH_TOKEN` and  `NOKO_TOKEN` from fixtures

**I will abide by the [code of conduct](code_of_conduct.md)**
